### PR TITLE
Update text-stream-search

### DIFF
--- a/lib/firefox.js
+++ b/lib/firefox.js
@@ -5,9 +5,7 @@ const UserError = require('./user-error')
 
 const webextBinPath = require.resolve('.bin/web-ext')
 
-// https://github.com/Originate/node-text-stream-search/issues/31
-let StreamSearch = require('text-stream-search')
-if (StreamSearch.default) StreamSearch = StreamSearch.default
+const { TextStreamSearch } = require('text-stream-search')
 
 module.exports = async function (source) {
   let errors = []
@@ -30,7 +28,7 @@ module.exports = async function (source) {
 
   try {
     const child = execa(webextBinPath, args, { stdio: ['ignore', 'pipe', 'inherit'] })
-    const searcher = new StreamSearch(child.stdout)
+    const searcher = new TextStreamSearch(child.stdout)
 
     let wasSubmitted = false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1927,11 +1927,6 @@
         }
       }
     },
-    "delay": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-4.1.0.tgz",
-      "integrity": "sha512-8Hea6/aOu3bPdDBQhSRUEUzF0QwuWmSPuIK+sxNdvcJtSfzb6HXrTd9DFJBCJcV9o83fFECqTgllqdnmUfq9+w=="
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -6113,59 +6108,10 @@
         }
       }
     },
-    "text-stream-accumulator": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/text-stream-accumulator/-/text-stream-accumulator-1.3.0.tgz",
-      "integrity": "sha512-peIB0yx+tdbWs6AN53IFg2ee7Pg8rbOpXnggmLn+aVcZ0fm4dzJxScPrN1tmbKQQ94H1CRsi3AvJRaAjDSFKTA==",
-      "requires": {
-        "@types/node": "11.11.6",
-        "debug": "4.1.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "11.11.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
-    },
     "text-stream-search": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/text-stream-search/-/text-stream-search-3.0.0.tgz",
-      "integrity": "sha512-WSCRi5ajwHVKwoABdLCUv+FyPP7hYMM1gGrPSWm5vBEyiWeAEPpNjmRp50n24Uvyd4mOrhqLAUzTkk8WLjOcRg==",
-      "requires": {
-        "debug": "4.1.1",
-        "delay": "4.1.0",
-        "text-stream-accumulator": "1.3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/text-stream-search/-/text-stream-search-4.0.0.tgz",
+      "integrity": "sha512-u7ZjOP7niZJOhCzXwSsSnhPFW7fewouLX3CGAefDxuqZGPeuKzg0QaJtJCKFirOF5T/z5P6pZSlR9hRdoHfdZQ=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "globby": "^9.2.0",
     "neodoc": "^2.0.0",
     "ora": "^3.4.0",
-    "text-stream-search": "^3.0.0",
+    "text-stream-search": "^4.0.0",
     "upload-opera-extension": "^1.0.2",
     "web-ext": "^3.0.0"
   },


### PR DESCRIPTION
Hey Linus! I have found that named exports from TypeScript work for both JS and TS files. So v4.0.0 of `text-stream-search` should fix the hacks that you had to do to use v3.0.0. As a nice side effect, v4.0.0 is also much simplified and smaller and now has zero dependencies. I didn't find any tests for `wext-shipit` so I can't guarantee that I haven't broken anything here. Since you were so nice to help resolve the issue on `text-stream-search` a while ago, I thought I return the favor and send you this update. Thanks!